### PR TITLE
Backwards compatibility and some PEP8...

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Handy tools for working with keyframes in Blender. Inspired by Alan Camilo's animBot.
 
-**Blender 2.8 breaks compatibility so it has its own branch.**
-
 ## Limitations
 
 This add-on is in its very early stages of development. It is offered here because people on Twitter were all "wow this looks awesome i want to try it".
@@ -48,11 +46,10 @@ You can also access the functions from the Function Search menu. (Space Bar on l
 
 ## Roadmap
 
-These are the current priorities as of version 0.6.0 (24 May 2019)
+These are the current priorities as of version 0.6.1 (27 June 2019)
 
 ### Coming Other Changes and Fixes
 
-* Blender 2.8 compatibility is underway!
 * All: Make all F-Curve types manipulable, including properties belonging to materials, scenes and worlds.
 * Ease: Do something more helpful with out-of-bounds keys 
 * Share Keys: Make it work again


### PR DESCRIPTION
I use macro functions to run checks for things and I add backwards compatibility in them, to propagate wherever possible.

I modified a developer's python script with enhancements using something similar and sent it to them as an addon. They said it was full of "anti-patterns" and hard to read. They didn't really elaborate and gave the impression that the problem was they didn't believe the code was ready as-is to be submitted directly to Blender (which wasn't my goal).

So, submitting this as a branch so you can look at it and see if you want to do it differently (if at all) before marking the commit logs and maybe reverting and etc.

- - - - - - -

Renamed [GRAPH_PIE_keyframetools_piemenu] to [GRAPH_MT_PIE_keyframetools_piemenu] and deleted the bl_idname because 2.8 throws a python warning for not having the _MT_ part, and bl_idname is not needed for this type of class (just a duplicate) unless you explicitly call to that variable inside the code for whatever reason.

line #101 I added a check for if a curve is selected, to only run if you select keyframes in it. I don't remember if that was a personal preference, or a bug fix.
Added bl_description to the classes, as a personal code-preference.

- - - - - - - - - -

Rather than use this one function I found online, to allow entering properties for 2.8, like in 2.7, I was just going to duplicate them. 
I re-looked at your version and double-checked that it worked, and found I didn't need to do either. 
Apparently at some point, Blender 2.8 started re-allowing use of equal{=} instead of only colon{:}

This would still be needed for people using "older" builds but I guess supporting that niche is a no-go.